### PR TITLE
Match hearing-centre-admin perms + fix mismatch of task names

### DIFF
--- a/src/main/resources/wa-task-configuration-publiclaw-care_supervision_epo.dmn
+++ b/src/main/resources/wa-task-configuration-publiclaw-care_supervision_epo.dmn
@@ -461,7 +461,7 @@
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1v6se2q">
-          <text>"reviewMessageAllocatedJudge","reviewResponseAllocatedJudge","reviewMessageHearingJudge","reviewResponseHearingJudge","reviewMessageLocalCourt","reviewResponseLocalCourt","reviewMessageCTSC","reviewResponseCTSC","reviewStandardDirectionOrder","reviewCorrespondence","checkPlacementApplication","chaseOutstandingOrder"</text>
+          <text>"reviewMessageAllocatedJudge","reviewResponseAllocatedJudge","reviewMessageHearingJudge","reviewResponseHearingJudge","reviewMessageHearingCentreAdmin","reviewResponseHearingCentreAdmin","reviewMessageCTSC","reviewResponseCTSC","reviewStandardDirectionOrder","reviewCorrespondence","checkPlacementApplication","chaseOutstandingOrder"</text>
         </inputEntry>
         <outputEntry id="LiteralExpression_08sdeu3">
           <text>"workType"</text>

--- a/src/main/resources/wa-task-permissions-publiclaw-care_supervision_epo.dmn
+++ b/src/main/resources/wa-task-permissions-publiclaw-care_supervision_epo.dmn
@@ -296,7 +296,7 @@
           <text>"hearing-centre-admin"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0hiioi6">
-          <text>"Complete,Own,Claim,Unclaim,UnassignClaim,Read"</text>
+          <text>"Complete,Own,Assign,Claim,Unassign,Read"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1br4qdl">
           <text>"ADMIN"</text>


### PR DESCRIPTION
### JIRA link (if applicable) ###



### Change description ###
 - Match the permissions for the other working events
 - Update the configuration DMN to match the right task name


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
