### PR TITLE
DFPL-1561,DFPL-1657: Update workTypes and add auto-assigning legal-adviser tasks

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -36,5 +36,6 @@
     <cve>CVE-2022-1471</cve>
     <cve>CVE-2023-20883</cve>
     <cve>CVE-2023-35116</cve>
+    <cve>CVE-2023-20873</cve>
    </suppress>
 </suppressions>

--- a/src/main/resources/wa-task-configuration-publiclaw-care_supervision_epo.dmn
+++ b/src/main/resources/wa-task-configuration-publiclaw-care_supervision_epo.dmn
@@ -444,7 +444,7 @@
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_08wb4e8">
-          <text>"viewAdditionalApplications","approveOrders","reviewOrderCMO"</text>
+          <text>"viewAdditionalApplications","approveOrders","reviewOrderCMO","reviewStandardDirectionOrder"</text>
         </inputEntry>
         <outputEntry id="LiteralExpression_0uxu3q4">
           <text>"workType"</text>
@@ -461,7 +461,7 @@
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1v6se2q">
-          <text>"reviewMessageAllocatedJudge","reviewResponseAllocatedJudge","reviewMessageHearingJudge","reviewResponseHearingJudge","reviewMessageHearingCentreAdmin","reviewResponseHearingCentreAdmin","reviewMessageCTSC","reviewResponseCTSC","reviewStandardDirectionOrder","reviewCorrespondence","checkPlacementApplication","chaseOutstandingOrder"</text>
+          <text>"reviewMessageAllocatedJudge","reviewResponseAllocatedJudge","reviewMessageHearingJudge","reviewResponseHearingJudge","reviewMessageHearingCentreAdmin","reviewResponseHearingCentreAdmin","reviewMessageCTSC","reviewResponseCTSC","reviewCorrespondence","chaseOutstandingOrder"</text>
         </inputEntry>
         <outputEntry id="LiteralExpression_08sdeu3">
           <text>"workType"</text>
@@ -478,7 +478,7 @@
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_178m83z">
-          <text>"reviewUrgentApplication","reviewStandardApplication","reviewFailedPayment"</text>
+          <text>"reviewUrgentApplication","reviewStandardApplication","checkPlacementApplication"</text>
         </inputEntry>
         <outputEntry id="LiteralExpression_1tzsh4h">
           <text>"workType"</text>
@@ -487,6 +487,23 @@
           <text>"applications"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0yekdr4">
+          <text>true</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1tquo8z">
+        <inputEntry id="UnaryTests_0m77n9i">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0ivrmz6">
+          <text>"reviewFailedPayment"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_18gtgat">
+          <text>"workType"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0mrzeni">
+          <text>"error_management"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0bqhn39">
           <text>true</text>
         </outputEntry>
       </rule>

--- a/src/main/resources/wa-task-permissions-publiclaw-care_supervision_epo.dmn
+++ b/src/main/resources/wa-task-permissions-publiclaw-care_supervision_epo.dmn
@@ -98,6 +98,33 @@
           <text>true</text>
         </outputEntry>
       </rule>
+      <rule id="DecisionRule_0ytac21">
+        <description>Auto assigning</description>
+        <inputEntry id="UnaryTests_1a0ljrj">
+          <text>"reviewMessageAllocatedJudge","reviewResponseAllocatedJudge"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1qh7zor">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0m4me1s">
+          <text>"allocated-legal-adviser"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0bbiov6">
+          <text>"Complete,Own,Assign,Claim,Unassign,Read"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_15n2gsm">
+          <text>"LEGAL_OPERATIONS"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0addcef">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0s5129z">
+          <text>2</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1fxv06l">
+          <text>true</text>
+        </outputEntry>
+      </rule>
       <rule id="DecisionRule_1vc7wl3">
         <description>Auto assigning</description>
         <inputEntry id="UnaryTests_05orfx0">
@@ -122,6 +149,33 @@
           <text>1</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1ybfy1r">
+          <text>true</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_18y776v">
+        <description>Auto assigning</description>
+        <inputEntry id="UnaryTests_19t8w4o">
+          <text>"reviewMessageHearingJudge","reviewResponseHearingJudge"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0967lem">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0eg54m7">
+          <text>"hearing-legal-adviser"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1yv1c8w">
+          <text>"Complete,Own,Assign,Claim,Unassign,Read"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_13b7zoz">
+          <text>"LEGAL_OPERATIONS"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1pvf7y7">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0ezgvdt">
+          <text>2</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0aiuyoc">
           <text>true</text>
         </outputEntry>
       </rule>
@@ -205,6 +259,33 @@
           <text>true</text>
         </outputEntry>
       </rule>
+      <rule id="DecisionRule_0urbbi8">
+        <description>Auto assigning</description>
+        <inputEntry id="UnaryTests_0fu4qre">
+          <text>"viewAdditionalApplications"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_12b4bo7">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0wctujd">
+          <text>"allocated-legal-adviser"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1ht5y1p">
+          <text>"Complete,Own,Assign,Claim,Unassign,Read"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_128edem">
+          <text>"LEGAL_OPERATIONS"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1dz3ckh">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1xv65mx">
+          <text>2</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1qg5z2e">
+          <text>true</text>
+        </outputEntry>
+      </rule>
       <rule id="DecisionRule_10ux7wt">
         <description></description>
         <inputEntry id="UnaryTests_1kf3gzz">
@@ -282,6 +363,33 @@
           <text>1</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_12mldj1">
+          <text>true</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_002pzao">
+        <description>Auto assigning</description>
+        <inputEntry id="UnaryTests_1g0d3xf">
+          <text>"approveOrders"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1hf0l9t">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_10w561m">
+          <text>"hearing-legal-adviser"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0d0thc1">
+          <text>"Complete,Own,Assign,Claim,Unassign,Read"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1erm8yd">
+          <text>"LEGAL_OPERATIONS"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1xutk8r">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_17bvc6d">
+          <text>2</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0l6z28r">
           <text>true</text>
         </outputEntry>
       </rule>

--- a/src/test/java/uk/gov/hmcts/reform/fpl/dmn/CamundaTaskWaConfigurationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/fpl/dmn/CamundaTaskWaConfigurationTest.java
@@ -63,7 +63,7 @@ class CamundaTaskWaConfigurationTest extends DmnDecisionTableBaseUnitTest {
     void shouldHaveCorrectNumberOfRules() {
         // The purpose of this test is to prevent adding new rows without being tested
         DmnDecisionTableImpl logic = (DmnDecisionTableImpl) decision.getDecisionLogic();
-        assertThat(logic.getRules().size(), is(61));
+        assertThat(logic.getRules().size(), is(62));
     }
 
     private static List<Map<String, Object>> getBaseValues() {

--- a/src/test/java/uk/gov/hmcts/reform/fpl/dmn/CamundaTaskWaPermissionsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/fpl/dmn/CamundaTaskWaPermissionsTest.java
@@ -74,7 +74,7 @@ class CamundaTaskWaPermissionsTest extends DmnDecisionTableBaseUnitTest {
     void shouldHaveCorrectNumberOfRules() {
         // The purpose of this test is to prevent adding new rows without being tested
         DmnDecisionTableImpl logic = (DmnDecisionTableImpl) decision.getDecisionLogic();
-        assertThat(logic.getRules().size(), is(18));
+        assertThat(logic.getRules().size(), is(22));
     }
 
     private static Map<String, Object> getRowResult(String name, String value, String roleCategory, String auth,


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DFPL-1657
https://tools.hmcts.net/jira/browse/DFPL-1561

### Change description ###
 - Add autoassigning legal-adviser tasks to match judicial equivalents
 - Update workTypes for 3 tasks


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
