### PR TITLE
DFPL-2031: Allow migrateCase to cancel tasks

### DIFF
--- a/src/main/resources/wa-task-cancellation-publiclaw-care_supervision_epo.dmn
+++ b/src/main/resources/wa-task-cancellation-publiclaw-care_supervision_epo.dmn
@@ -137,6 +137,78 @@
           <text></text>
         </outputEntry>
       </rule>
+      <rule id="DecisionRule_1qu7o48">
+        <description>Allow a migration to cancel all outstanding tasks</description>
+        <inputEntry id="UnaryTests_15toito">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0pxec20">
+          <text>"migrateCase"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0xuf6r2">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1o76v8o">
+          <text>"Cancel"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1k6ly5g">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1s58p9g">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1s4ybmw">
+          <text>"case progression"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_12r9lqr">
+        <description>Allow a migration to cancel all outstanding tasks</description>
+        <inputEntry id="UnaryTests_1rpg23x">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1u8dg7z">
+          <text>"migrateCase"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1gu0wrl">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0vwcmc0">
+          <text>"Cancel"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1aqn61s">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1ctvjj5">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1c57dbb">
+          <text>"case creation"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0y87zzt">
+        <description>Allow a migration to cancel all outstanding tasks</description>
+        <inputEntry id="UnaryTests_1l6r74p">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1eub5m4">
+          <text>"migrateCase"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0flgsiw">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0kqk2pj">
+          <text>"Cancel"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0ai7a0h">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0ono54h">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1w9svub">
+          <text>"manage outcome"</text>
+        </outputEntry>
+      </rule>
     </decisionTable>
   </decision>
   <dmndi:DMNDI>

--- a/src/test/java/uk/gov/hmcts/reform/fpl/dmn/CamundaTaskWaCancellationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/fpl/dmn/CamundaTaskWaCancellationTest.java
@@ -17,7 +17,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
-import static java.util.Collections.singletonList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/src/test/java/uk/gov/hmcts/reform/fpl/dmn/CamundaTaskWaCancellationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/fpl/dmn/CamundaTaskWaCancellationTest.java
@@ -13,12 +13,14 @@ import uk.gov.hmcts.reform.fpl.DmnDecisionTable;
 import uk.gov.hmcts.reform.fpl.DmnDecisionTableBaseUnitTest;
 
 import java.io.Serializable;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
 import static java.util.Collections.singletonList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class CamundaTaskWaCancellationTest extends DmnDecisionTableBaseUnitTest {
 
@@ -30,7 +32,7 @@ class CamundaTaskWaCancellationTest extends DmnDecisionTableBaseUnitTest {
     @ParameterizedTest
     @MethodSource("scenarioProvider")
     void givenInputShouldReturnOutcomeDmn(String eventId,
-                                               Map<String, ? extends Serializable> expectedDmnOutcome) {
+                                               List<Map<String, ? extends Serializable>> expectedDmnOutcome) {
         VariableMap inputVariables = new VariableMapImpl();
         inputVariables.putValue("event", eventId);
         inputVariables.putValue("fromState", "");
@@ -38,16 +40,20 @@ class CamundaTaskWaCancellationTest extends DmnDecisionTableBaseUnitTest {
 
         DmnDecisionTableResult dmnDecisionTableResult = evaluateDmnTable(inputVariables);
 
-        assertThat(dmnDecisionTableResult.getResultList(), is(singletonList(expectedDmnOutcome)));
+        assertTrue(dmnDecisionTableResult.getResultList().containsAll(expectedDmnOutcome));
     }
 
     public static Stream<Arguments> scenarioProvider() {
         return Stream.of(
-            Arguments.of("manageHearings", Map.of("action", "Reconfigure")),
-            Arguments.of("changeCaseName", Map.of("action", "Reconfigure")),
-            Arguments.of("changeCaseName-superuser", Map.of("action", "Reconfigure")),
-            Arguments.of("manageLocalAuthorities", Map.of("action", "Reconfigure")),
-            Arguments.of("internal-update-case-summary", Map.of("action", "Reconfigure"))
+            Arguments.of("manageHearings", List.of(Map.of("action", "Reconfigure"))),
+            Arguments.of("changeCaseName", List.of(Map.of("action", "Reconfigure"))),
+            Arguments.of("changeCaseName-superuser", List.of(Map.of("action", "Reconfigure"))),
+            Arguments.of("manageLocalAuthorities", List.of(Map.of("action", "Reconfigure"))),
+            Arguments.of("internal-update-case-summary", List.of(Map.of("action", "Reconfigure"))),
+            Arguments.of("migrateCase", List.of(
+                Map.of("action", "Cancel", "processCategories", "case progression"),
+                Map.of("action", "Cancel", "processCategories", "case creation"),
+                Map.of("action", "Cancel", "processCategories", "manage outcome")))
         );
     }
 
@@ -55,6 +61,6 @@ class CamundaTaskWaCancellationTest extends DmnDecisionTableBaseUnitTest {
     void shouldHaveCorrectNumberOfRules() {
         // The purpose of this test is to prevent adding new rows without being tested
         DmnDecisionTableImpl logic = (DmnDecisionTableImpl) decision.getDecisionLogic();
-        assertThat(logic.getRules().size(), is(5));
+        assertThat(logic.getRules().size(), is(8));
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DFPL-2031


### Change description ###
 - Allow migrateCase to cancel tasks for a cleanup migration 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
