### PR TITLE
DFPl-2009: Fix WA task creation for non-urgent application without a hearing

### DIFF
--- a/src/main/resources/wa-task-initiation-publiclaw-care_supervision_epo.dmn
+++ b/src/main/resources/wa-task-initiation-publiclaw-care_supervision_epo.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0swvthw" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.16.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.17.0">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0swvthw" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.19.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.17.0">
   <decision id="wa-task-initiation-publiclaw-care_supervision_epo" name="Task initiation DMN" camunda:historyTimeToLive="P30D">
     <decisionTable id="DecisionTable_1fj3kaa" hitPolicy="RULE ORDER">
       <input id="Input_1" label="Event Id" camunda:inputVariable="eventId">
@@ -22,7 +22,7 @@
       </input>
       <input id="InputClause_01shufq" label="Hearing Timeframe" camunda:inputVariable="timeFrame">
         <inputExpression id="LiteralExpression_13k9gdq" typeRef="string">
-          <text>if(additionalData != null and additionalData.Data != null and additionalData.Data.hearing != null and additionalData.Data.hearing.timeFrame != null) then additionalData.Data.hearing.timeFrame else null</text>
+          <text>if(additionalData != null and additionalData.Data != null) then if(additionalData.hearing.timeFrame != null and additionalData.Data.hearing != null) then additionalData.hearing.timeFrame else “Other” else null</text>
         </inputExpression>
         <inputValues id="UnaryTests_1e9vfmg">
           <text>"Within 5 days","Within 2 days","Same day"</text>

--- a/src/main/resources/wa-task-initiation-publiclaw-care_supervision_epo.dmn
+++ b/src/main/resources/wa-task-initiation-publiclaw-care_supervision_epo.dmn
@@ -22,7 +22,7 @@
       </input>
       <input id="InputClause_01shufq" label="Hearing Timeframe" camunda:inputVariable="timeFrame">
         <inputExpression id="LiteralExpression_13k9gdq" typeRef="string">
-          <text>if(additionalData != null and additionalData.Data != null) then if(additionalData.hearing.timeFrame != null and additionalData.Data.hearing != null) then additionalData.hearing.timeFrame else “Other” else null</text>
+          <text>if(additionalData != null and additionalData.Data != null and additionalData.Data.hearing != null and additionalData.Data.hearing.timeFrame != null) then additionalData.Data.hearing.timeFrame else "Other"</text>
         </inputExpression>
         <inputValues id="UnaryTests_1e9vfmg">
           <text>"Within 5 days","Within 2 days","Same day"</text>

--- a/src/test/java/uk/gov/hmcts/reform/fpl/dmn/CamundaTaskWaInitiationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/fpl/dmn/CamundaTaskWaInitiationTest.java
@@ -153,6 +153,6 @@ class CamundaTaskWaInitiationTest extends DmnDecisionTableBaseUnitTest {
         // The purpose of this test is to prevent adding new rows without being tested
         DmnDecisionTableImpl logic = (DmnDecisionTableImpl) decision.getDecisionLogic();
         // todo - check this after evaluation period
-        assertThat(logic.getRules().size(), is(20));
+        assertThat(logic.getRules().size(), is(21));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/fpl/dmn/CamundaTaskWaPermissionsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/fpl/dmn/CamundaTaskWaPermissionsTest.java
@@ -74,7 +74,7 @@ class CamundaTaskWaPermissionsTest extends DmnDecisionTableBaseUnitTest {
     void shouldHaveCorrectNumberOfRules() {
         // The purpose of this test is to prevent adding new rows without being tested
         DmnDecisionTableImpl logic = (DmnDecisionTableImpl) decision.getDecisionLogic();
-        assertThat(logic.getRules().size(), is(22));
+        assertThat(logic.getRules().size(), is(23));
     }
 
     private static Map<String, Object> getRowResult(String name, String value, String roleCategory, String auth,


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DFPL-2009

Add branch for hearing timeframe check in DMN tables to allow for application without a hearing timeframe

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
