### PR TITLE
Fix missing quotes in task type filter DMN

### DIFF
--- a/src/main/resources/wa-task-types-publiclaw-care_supervision_epo.dmn
+++ b/src/main/resources/wa-task-types-publiclaw-care_supervision_epo.dmn
@@ -179,7 +179,7 @@
           <text></text>
         </inputEntry>
         <outputEntry id="LiteralExpression_0youqbh">
-          <text>reviewStandardDirectionOrderHighCourt</text>
+          <text>"reviewStandardDirectionOrderHighCourt"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_03k48i2">
           <text>"Review Standard Direction Order (High Court)"</text>
@@ -271,17 +271,6 @@
         </outputEntry>
         <outputEntry id="LiteralExpression_0dxuuq8">
           <text>"Check Placement Application (High Court)"</text>
-        </outputEntry>
-      </rule>
-      <rule id="DecisionRule_0972qcs">
-        <inputEntry id="UnaryTests_17em3ml">
-          <text></text>
-        </inputEntry>
-        <outputEntry id="LiteralExpression_006764i">
-          <text></text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_11rgq3v">
-          <text></text>
         </outputEntry>
       </rule>
     </decisionTable>


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
 - Wrap one task type in quotes to fix errors with task type filter


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
