### PR TITLE
DFPL-2480: Use case-insensitive match, not `ends with`

### DIFF
--- a/src/main/resources/wa-task-configuration-publiclaw-care_supervision_epo.dmn
+++ b/src/main/resources/wa-task-configuration-publiclaw-care_supervision_epo.dmn
@@ -623,8 +623,7 @@ else "roleAssignmentId"</text>
           <text>"roleCategory"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_13wjipi">
-          <text>if (
-    ends with(caseData.allocatedJudge.judgeEmailAddress, "@justice.gov.uk")
+          <text>if ( matches(caseData.allocatedJudge.judgeEmailAddress, "@justice.gov.uk", "i")
     or caseData.allocatedJudge.judgeTitle = "LEGAL_ADVISOR"
 ) 
 then "LEGAL_OPERATIONS" 
@@ -653,14 +652,14 @@ else "JUDICIAL"</text>
         ].value,
         precedes: function(x, y) x.startDate &gt;= y.startDate
     )[1].judgeAndLegalAdvisor.judgeTitle = "LEGAL_ADVISOR" 
-    or ends with(
+    or matches(
         sort(
             list: caseData.hearingDetails[
                 date and time(item.value.startDate) 
                 &lt;= date and time(substring(string(date(now())), 1, 10) + "T" + substring(string(time(now())), 1, 8))
             ].value,
             precedes: function(x, y) x.startDate &gt;= y.startDate
-        )[1].judgeAndLegalAdvisor.judgeEmailAddress, "@justice.gov.uk")
+        )[1].judgeAndLegalAdvisor.judgeEmailAddress, "@justice.gov.uk", "i")
 ) 
 then "LEGAL_OPERATIONS" 
 else if (
@@ -671,7 +670,7 @@ else if (
         ].value,
         precedes: function(x, y) x.startDate &gt;= y.startDate
     )[1] = null) and    
-    (ends with(caseData.allocatedJudge.judgeEmailAddress, "@justice.gov.uk")
+    (matches(caseData.allocatedJudge.judgeEmailAddress, "@justice.gov.uk", "i")
     or caseData.allocatedJudge.judgeTitle = "LEGAL_ADVISOR")
 ) 
 then "LEGAL_OPERATIONS" 

--- a/src/test/java/uk/gov/hmcts/reform/fpl/dmn/CamundaTaskWaConfigurationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/fpl/dmn/CamundaTaskWaConfigurationTest.java
@@ -132,6 +132,12 @@ class CamundaTaskWaConfigurationTest extends DmnDecisionTableBaseUnitTest {
                 ))
             ),
             Arguments.of(
+                "LEGAL_OPERATIONS",
+                Map.of("allocatedJudge", Map.of("judgeTitle", "MAGISTRATE",
+                                                "judgeEmailAddress", "test@Justice.gov.uk"
+                ))
+            ),
+            Arguments.of(
                 "JUDICIAL",
                 Map.of("allocatedJudge", Map.of("judgeTitle", "HER_HONOUR_JUDGE",
                                                 "judgeEmailAddress", "test@whatever.com"
@@ -362,6 +368,33 @@ class CamundaTaskWaConfigurationTest extends DmnDecisionTableBaseUnitTest {
                                    "judgeAndLegalAdvisor", Map.of(
                                        "judgeTitle", "MR_JUSTICE",
                                        "judgeEmailAddress", "whatever@whatever.com"
+                                   )
+                               )
+                           ),
+                           Map.of("id", UUID.randomUUID(),
+                                  "value", Map.of(
+                                   "startDate", getFutureStartDate(),
+                                   "judgeAndLegalAdvisor", Map.of(
+                                       "judgeTitle", "LEGAL_ADVISOR",
+                                       "judgeEmailAddress", "whatever@justice.gov.uk"
+                                   )
+                               )
+                           )
+                       ),
+                       "allocatedJudge", Map.of("judgeTitle", "LEGAL_ADVISOR",
+                                                "judgeEmailAddress", "whatever@justice.gov.uk"
+                    )
+                )
+            ),
+            Arguments.of(
+                "LEGAL_OPERATIONS",
+                Map.of("hearingDetails", List.of(
+                           Map.of("id", UUID.randomUUID(),
+                                  "value", Map.of(
+                                   "startDate", getPastStartDate(),
+                                   "judgeAndLegalAdvisor", Map.of(
+                                       "judgeTitle", "MAGISTRATE",
+                                       "judgeEmailAddress", "whatever@Justice.gov.uk"
                                    )
                                )
                            ),


### PR DESCRIPTION
### JIRA link (if applicable) ###
[DFPL-2480](https://tools.hmcts.net/jira/browse/DFPL-2480)


### Change description ###
 - Use case-insensitive `match`ing, not `ends with` (case sensitive)
 - Add scenarios to existing tests to verify this

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
