### PR TITLE
Fix missing legal adviser permission on judicial messages

### DIFF
--- a/src/main/resources/wa-task-permissions-publiclaw-care_supervision_epo.dmn
+++ b/src/main/resources/wa-task-permissions-publiclaw-care_supervision_epo.dmn
@@ -71,6 +71,32 @@
           <text>false</text>
         </outputEntry>
       </rule>
+      <rule id="DecisionRule_0lkgi61">
+        <inputEntry id="UnaryTests_1hyb7mt">
+          <text>"reviewMessageAllocatedJudge","reviewResponseAllocatedJudge","reviewMessageHearingJudge","reviewResponseHearingJudge"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0ieney8">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1w8h8oc">
+          <text>"tribunal-caseworker"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_11cz9va">
+          <text>"Complete,Own,Assign,Claim,Unassign,Read"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0ws78nd">
+          <text>"LEGAL_OPERATIONS"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_11oic7q">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_15quwa9">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1v4t5ri">
+          <text>false</text>
+        </outputEntry>
+      </rule>
       <rule id="DecisionRule_0kail0l">
         <description>Auto assigning</description>
         <inputEntry id="UnaryTests_1ezfkar">

--- a/src/test/java/uk/gov/hmcts/reform/fpl/dmn/CamundaTaskWaPermissionsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/fpl/dmn/CamundaTaskWaPermissionsTest.java
@@ -74,7 +74,7 @@ class CamundaTaskWaPermissionsTest extends DmnDecisionTableBaseUnitTest {
     void shouldHaveCorrectNumberOfRules() {
         // The purpose of this test is to prevent adding new rows without being tested
         DmnDecisionTableImpl logic = (DmnDecisionTableImpl) decision.getDecisionLogic();
-        assertThat(logic.getRules().size(), is(23));
+        assertThat(logic.getRules().size(), is(24));
     }
 
     private static Map<String, Object> getRowResult(String name, String value, String roleCategory, String auth,


### PR DESCRIPTION
### JIRA link (if applicable) ###
TBC


### Change description ###
 - Add missing legal adviser (tribunal-caseworker) base permission for review message tasks


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
