### PR TITLE
Allow judges to be assigned messages when incorrectly sent to a non-existent legal adviser

### DIFF
--- a/src/main/resources/wa-task-permissions-publiclaw-care_supervision_epo.dmn
+++ b/src/main/resources/wa-task-permissions-publiclaw-care_supervision_epo.dmn
@@ -551,6 +551,32 @@
           <text>true</text>
         </outputEntry>
       </rule>
+      <rule id="DecisionRule_0jhmjko">
+        <inputEntry id="UnaryTests_15ms8bl">
+          <text>"reviewMessageLegalAdviser","reviewResponseLegalAdviser"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1vs6wxu">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1wc6k70">
+          <text>"judge"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1dzofyx">
+          <text>"Complete,Own,Assign,Claim,Unassign,Read"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_184h3l4">
+          <text>"JUDICIAL"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0hcrzh3">
+          <text>316</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_06jkoj5">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0ghj18o">
+          <text>false</text>
+        </outputEntry>
+      </rule>
       <rule id="DecisionRule_1n5hisj">
         <inputEntry id="UnaryTests_084wyb5">
           <text>"reviewSpecificAccessRequestLegalOps"</text>

--- a/src/test/java/uk/gov/hmcts/reform/fpl/dmn/CamundaTaskWaPermissionsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/fpl/dmn/CamundaTaskWaPermissionsTest.java
@@ -74,7 +74,7 @@ class CamundaTaskWaPermissionsTest extends DmnDecisionTableBaseUnitTest {
     void shouldHaveCorrectNumberOfRules() {
         // The purpose of this test is to prevent adding new rows without being tested
         DmnDecisionTableImpl logic = (DmnDecisionTableImpl) decision.getDecisionLogic();
-        assertThat(logic.getRules().size(), is(24));
+        assertThat(logic.getRules().size(), is(25));
     }
 
     private static Map<String, Object> getRowResult(String name, String value, String roleCategory, String auth,


### PR DESCRIPTION
### JIRA link (if applicable) ###
TBC


### Change description ###
 - Add judge permission to allow them to be assigned tasks even if the user chose "legal adviser" incorrectly


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
