### PR TITLE
Fix missing workType for legal adviser messages

### DIFF
--- a/src/main/resources/wa-task-configuration-publiclaw-care_supervision_epo.dmn
+++ b/src/main/resources/wa-task-configuration-publiclaw-care_supervision_epo.dmn
@@ -544,7 +544,7 @@
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1v6se2q">
-          <text>"reviewMessageAllocatedJudge","reviewResponseAllocatedJudge","reviewMessageHearingJudge","reviewResponseHearingJudge","reviewMessageHearingCentreAdmin","reviewResponseHearingCentreAdmin","reviewMessageCTSC","reviewResponseCTSC","reviewCorrespondence","chaseOutstandingOrder","reviewCorrespondenceHighCourt","reviewListingAction"</text>
+          <text>"reviewMessageAllocatedJudge","reviewResponseAllocatedJudge","reviewMessageHearingJudge","reviewResponseHearingJudge","reviewMessageHearingCentreAdmin","reviewResponseHearingCentreAdmin","reviewMessageCTSC","reviewResponseCTSC","reviewMessageLegalAdviser","reviewResponseLegalAdviser","reviewCorrespondence","chaseOutstandingOrder","reviewCorrespondenceHighCourt","reviewListingAction"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1attt77">
           <text></text>


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
 - Add workType for "reviewMessageLegalAdviser", "reviewResponseLegalAdviser"


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
