### PR TITLE
DFPL-2664: Switch OTHER tasks over to generic judiciary messages

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/fpl/dmn/FplTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/fpl/dmn/FplTask.java
@@ -1,5 +1,8 @@
 package uk.gov.hmcts.reform.fpl.dmn;
 
+import lombok.Getter;
+
+@Getter
 public enum FplTask {
 
     REVIEW_MESSAGE_ALLOCATED_JUDGE("reviewMessageAllocatedJudge"),
@@ -10,7 +13,12 @@ public enum FplTask {
     REVIEW_RESPONSE_HEARING_CENTRE_ADMIN("reviewResponseHearingCentreAdmin"),
     REVIEW_MESSAGE_CTSC("reviewMessageCTSC"),
     REVIEW_RESPONSE_CTSC("reviewResponseCTSC"),
+    REVIEW_MESSAGE_OTHER("reviewMessageOther"),
+    REVIEW_RESPONSE_OTHER("reviewResponseOther"),
+    // Use REVIEW_MESSAGE_OTHER instead
+    @Deprecated(since = "DFPL-2664")
     REVIEW_MESSAGE_LEGAL_ADVISOR("reviewMessageLegalAdviser"),
+    @Deprecated(since = "DFPL-2664")
     REVIEW_RESPONSE_LEGAL_ADVISOR("reviewResponseLegalAdviser"),
     VIEW_ADDITIONAL_APPLICATIONS("viewAdditionalApplications"),
     APPROVE_ORDERS("approveOrders"),
@@ -24,14 +32,10 @@ public enum FplTask {
     CHASE_OUTSTANDING_ORDER("chaseOutstandingOrder"),
     REVIEW_LISTING_ACTION("reviewListingAction");
 
-    private String value;
+    private final String value;
 
     FplTask(String value) {
         this.value = value;
-    }
-
-    public String getValue() {
-        return this.value;
     }
 
 

--- a/src/main/resources/wa-task-completion-publiclaw-care_supervision_epo.dmn
+++ b/src/main/resources/wa-task-completion-publiclaw-care_supervision_epo.dmn
@@ -111,6 +111,7 @@
         </outputEntry>
       </rule>
       <rule id="DecisionRule_0trav2o">
+        <description>DEPRECATED</description>
         <inputEntry id="UnaryTests_0ooic7u">
           <text>"replyToMessageJudgeOrLegalAdviser"</text>
         </inputEntry>
@@ -122,6 +123,7 @@
         </outputEntry>
       </rule>
       <rule id="DecisionRule_0a3rjv3">
+        <description>DEPRECATED</description>
         <inputEntry id="UnaryTests_14min44">
           <text>"replyToMessageJudgeOrLegalAdviser"</text>
         </inputEntry>
@@ -129,6 +131,28 @@
           <text>"reviewResponseLegalAdviser"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_09lngvv">
+          <text>"Auto"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1agq3zj">
+        <inputEntry id="UnaryTests_05m61v2">
+          <text>"replyToMessageJudgeOrLegalAdviser"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_074j4d2">
+          <text>"reviewMessageOther"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0nxj107">
+          <text>"Auto"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1q25bc5">
+        <inputEntry id="UnaryTests_1s1cp38">
+          <text>"replyToMessageJudgeOrLegalAdviser"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0yug9yn">
+          <text>"reviewResponseOther"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1apidmd">
           <text>"Auto"</text>
         </outputEntry>
       </rule>

--- a/src/main/resources/wa-task-configuration-publiclaw-care_supervision_epo.dmn
+++ b/src/main/resources/wa-task-configuration-publiclaw-care_supervision_epo.dmn
@@ -544,7 +544,7 @@
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1v6se2q">
-          <text>"reviewMessageAllocatedJudge","reviewResponseAllocatedJudge","reviewMessageHearingJudge","reviewResponseHearingJudge","reviewMessageHearingCentreAdmin","reviewResponseHearingCentreAdmin","reviewMessageCTSC","reviewResponseCTSC","reviewMessageLegalAdviser","reviewResponseLegalAdviser","reviewCorrespondence","chaseOutstandingOrder","reviewCorrespondenceHighCourt","reviewListingAction"</text>
+          <text>"reviewMessageAllocatedJudge","reviewResponseAllocatedJudge","reviewMessageHearingJudge","reviewResponseHearingJudge","reviewMessageHearingCentreAdmin","reviewResponseHearingCentreAdmin","reviewMessageCTSC","reviewResponseCTSC","reviewMessageLegalAdviser","reviewResponseLegalAdviser","reviewCorrespondence","chaseOutstandingOrder","reviewCorrespondenceHighCourt","reviewListingAction","reviewMessageOther","reviewResponseOther"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1attt77">
           <text></text>
@@ -666,7 +666,7 @@ else "roleAssignmentId"</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1c1bkfo">
-          <text>"reviewSpecificAccessRequestJudiciary"</text>
+          <text>"reviewSpecificAccessRequestJudiciary","reviewMessageOther","reviewResponseOther"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0mau698">
           <text></text>
@@ -821,7 +821,7 @@ else "JUDICIAL"</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0b9sm9k">
-          <text>"reviewMessageAllocatedJudge","reviewResponseAllocatedJudge","reviewMessageHearingJudge","reviewResponseHearingJudge","reviewMessageHearingCentreAdmin","reviewResponseHearingCentreAdmin","reviewMessageCTSC","reviewResponseCTSC","reviewMessageLegalAdviser","reviewResponseLegalAdviser"</text>
+          <text>"reviewMessageAllocatedJudge","reviewResponseAllocatedJudge","reviewMessageHearingJudge","reviewResponseHearingJudge","reviewMessageHearingCentreAdmin","reviewResponseHearingCentreAdmin","reviewMessageCTSC","reviewResponseCTSC","reviewMessageLegalAdviser","reviewResponseLegalAdviser","reviewMessageOther","reviewResponseOther"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1960ml5">
           <text></text>
@@ -1182,6 +1182,27 @@ else "JUDICIAL"</text>
           <text>false</text>
         </outputEntry>
       </rule>
+      <rule id="DecisionRule_0wkt147">
+        <description>Low/Medium/High based on priority date</description>
+        <inputEntry id="UnaryTests_17gmodg">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_08f6796">
+          <text>"reviewMessageOther","reviewResponseOther"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1v6yec1">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1ed2gij">
+          <text>"majorPriority"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0abk3pl">
+          <text>5000</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1mwdgor">
+          <text>false</text>
+        </outputEntry>
+      </rule>
       <rule id="DecisionRule_0jyvt7i">
         <description>Always High</description>
         <inputEntry id="UnaryTests_0eardmm">
@@ -1428,7 +1449,7 @@ else [5000])[1]</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0qd59ye">
-          <text>"viewAdditionalApplications","reviewMessageCTSC","reviewMessageLegalAdviser","reviewMessageHearingCentreAdmin","reviewMessageHearingJudge","reviewMessageAllocatedJudge","approveOrders","reviewOrderCMO","reviewResponseAllocatedJudge","reviewResponseHearingJudge","reviewResponseHearingCentreAdmin","reviewResponseCTSC"</text>
+          <text>"viewAdditionalApplications","reviewMessageCTSC","reviewMessageLegalAdviser","reviewMessageHearingCentreAdmin","reviewMessageHearingJudge","reviewMessageAllocatedJudge","approveOrders","reviewOrderCMO","reviewResponseAllocatedJudge","reviewResponseHearingJudge","reviewResponseHearingCentreAdmin","reviewResponseCTSC","reviewMessageOther","reviewResponseOther"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0nf7hes">
           <text></text>

--- a/src/main/resources/wa-task-initiation-publiclaw-care_supervision_epo.dmn
+++ b/src/main/resources/wa-task-initiation-publiclaw-care_supervision_epo.dmn
@@ -315,10 +315,10 @@
           <text>"151","123","203","139","130","242","303","131","115"</text>
         </inputEntry>
         <outputEntry id="LiteralExpression_0r3jvwx">
-          <text>"reviewMessageLegalAdviser"</text>
+          <text>"reviewMessageOther"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1ot1ycd">
-          <text>"Review Message (Legal Adviser)"</text>
+          <text>"Review Message (Other Judiciary)"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1swkc9j">
           <text></text>
@@ -354,10 +354,10 @@
           <text>"151","123","203","139","130","242","303","131","115"</text>
         </inputEntry>
         <outputEntry id="LiteralExpression_1r67fkh">
-          <text>"reviewResponseLegalAdviser"</text>
+          <text>"reviewResponseOther"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_01wni72">
-          <text>"Review Response (Legal Adviser)"</text>
+          <text>"Review Response (Other Judiciary)"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0dh2umt">
           <text></text>

--- a/src/main/resources/wa-task-permissions-publiclaw-care_supervision_epo.dmn
+++ b/src/main/resources/wa-task-permissions-publiclaw-care_supervision_epo.dmn
@@ -47,7 +47,7 @@
       <rule id="DecisionRule_1s2rbf3">
         <description></description>
         <inputEntry id="UnaryTests_1gultec">
-          <text>"reviewMessageAllocatedJudge","reviewResponseAllocatedJudge","reviewMessageHearingJudge","reviewResponseHearingJudge"</text>
+          <text>"reviewMessageAllocatedJudge","reviewResponseAllocatedJudge","reviewMessageHearingJudge","reviewResponseHearingJudge","reviewMessageOther","reviewResponseOther"</text>
         </inputEntry>
         <outputEntry id="LiteralExpression_0vdp8e1">
           <text></text>
@@ -73,7 +73,7 @@
       </rule>
       <rule id="DecisionRule_0lkgi61">
         <inputEntry id="UnaryTests_1hyb7mt">
-          <text>"reviewMessageAllocatedJudge","reviewResponseAllocatedJudge","reviewMessageHearingJudge","reviewResponseHearingJudge"</text>
+          <text>"reviewMessageAllocatedJudge","reviewResponseAllocatedJudge","reviewMessageHearingJudge","reviewResponseHearingJudge","reviewMessageOther","reviewResponseOther"</text>
         </inputEntry>
         <outputEntry id="LiteralExpression_0ieney8">
           <text></text>
@@ -421,7 +421,7 @@
       </rule>
       <rule id="DecisionRule_09x1weo">
         <inputEntry id="UnaryTests_1an08mt">
-          <text>"reviewMessageHearingCentreAdmin","reviewResponseHearingCentreAdmin"</text>
+          <text>"reviewMessageHearingCentreAdmin","reviewResponseHearingCentreAdmin","viewAdditionalApplications"</text>
         </inputEntry>
         <outputEntry id="LiteralExpression_08wkeq2">
           <text></text>
@@ -442,6 +442,60 @@
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0yx9iny">
+          <text>false</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_09g3ije">
+        <description>for ensuring tasks are reassigned when necessary</description>
+        <inputEntry id="UnaryTests_0rciqrm">
+          <text>"reviewMessageHearingCentreAdmin","reviewResponseHearingCentreAdmin","approveOrders","reviewMessageAllocatedJudge","reviewResponseAllocatedJudge","reviewMessageHearingJudge","reviewResponseHearingJudge","reviewMessageOther","reviewResponseOther"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_05tds6d">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_04e5ghc">
+          <text>"ctsc"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0k2fyzd">
+          <text>"Assign,Unassign,Read"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0dgxpvu">
+          <text>"CTSC"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1ul03ob">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_02sdcep">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_05549om">
+          <text>false</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1u9jc6e">
+        <description>for ensuring tasks are reassigned when necessary</description>
+        <inputEntry id="UnaryTests_19846qw">
+          <text>"reviewMessageHearingCentreAdmin","reviewResponseHearingCentreAdmin","approveOrders","reviewMessageAllocatedJudge","reviewResponseAllocatedJudge","reviewMessageHearingJudge","reviewResponseHearingJudge","reviewMessageOther","reviewResponseOther"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0dykfnl">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_13akzv2">
+          <text>"hearing-centre-admin"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0bp0554">
+          <text>"Assign,Unassign,Read"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1fal6bn">
+          <text>"ADMIN"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0oqxct1">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1nzuf2t">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1azn9k9">
           <text>false</text>
         </outputEntry>
       </rule>
@@ -498,7 +552,7 @@
         </outputEntry>
       </rule>
       <rule id="DecisionRule_1oooaja">
-        <description></description>
+        <description>DEPRECATED</description>
         <inputEntry id="UnaryTests_11vlyzo">
           <text>"reviewMessageLegalAdviser","reviewResponseLegalAdviser"</text>
         </inputEntry>
@@ -525,7 +579,7 @@
         </outputEntry>
       </rule>
       <rule id="DecisionRule_03nv4et">
-        <description>Auto assigning</description>
+        <description>Auto assigning, DEPRECATED</description>
         <inputEntry id="UnaryTests_0kypttb">
           <text>"reviewMessageLegalAdviser","reviewResponseLegalAdviser"</text>
         </inputEntry>
@@ -552,6 +606,7 @@
         </outputEntry>
       </rule>
       <rule id="DecisionRule_0jhmjko">
+        <description>DEPRECATED</description>
         <inputEntry id="UnaryTests_15ms8bl">
           <text>"reviewMessageLegalAdviser","reviewResponseLegalAdviser"</text>
         </inputEntry>

--- a/src/main/resources/wa-task-types-publiclaw-care_supervision_epo.dmn
+++ b/src/main/resources/wa-task-types-publiclaw-care_supervision_epo.dmn
@@ -119,6 +119,28 @@
           <text>"Review Response (Legal Adviser)"</text>
         </outputEntry>
       </rule>
+      <rule id="DecisionRule_1pt29vh">
+        <inputEntry id="UnaryTests_17qb2c6">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_149x4ag">
+          <text>"reviewMessageOther"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0ndv21b">
+          <text>"Review Message (Other Judiciary)"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_18pc57d">
+        <inputEntry id="UnaryTests_1pa3db9">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0f3y9o2">
+          <text>"reviewResponseOther"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1infklm">
+          <text>"Review Response (Other Judiciary)"</text>
+        </outputEntry>
+      </rule>
       <rule id="DecisionRule_1dv38vf">
         <inputEntry id="UnaryTests_0wbfgz0">
           <text></text>

--- a/src/test/java/uk/gov/hmcts/reform/fpl/dmn/CamundaTaskWaCompletionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/fpl/dmn/CamundaTaskWaCompletionTest.java
@@ -48,7 +48,7 @@ class CamundaTaskWaCompletionTest extends DmnDecisionTableBaseUnitTest {
                 FplTask.REVIEW_MESSAGE_HEARING_JUDGE, FplTask.REVIEW_RESPONSE_HEARING_JUDGE,
                 FplTask.REVIEW_MESSAGE_HEARING_CENTRE_ADMIN, FplTask.REVIEW_RESPONSE_HEARING_CENTRE_ADMIN,
                 FplTask.REVIEW_MESSAGE_CTSC, FplTask.REVIEW_RESPONSE_CTSC, FplTask.REVIEW_MESSAGE_LEGAL_ADVISOR,
-                FplTask.REVIEW_RESPONSE_LEGAL_ADVISOR
+                FplTask.REVIEW_RESPONSE_LEGAL_ADVISOR, FplTask.REVIEW_MESSAGE_OTHER, FplTask.REVIEW_RESPONSE_OTHER
             )),
             Arguments.of("sendToGatekeeper", getAutoCompleteTaskTypes(
                 FplTask.REVIEW_URGENT_APPLICATION,
@@ -66,7 +66,7 @@ class CamundaTaskWaCompletionTest extends DmnDecisionTableBaseUnitTest {
     void shouldHaveCorrectNumberOfRules() {
         // The purpose of this test is to prevent adding new rows without being tested
         DmnDecisionTableImpl logic = (DmnDecisionTableImpl) decision.getDecisionLogic();
-        assertThat(logic.getRules().size(), is(18));
+        assertThat(logic.getRules().size(), is(20));
     }
 
     private static Map<String, String> getAutoCompleteTaskType(FplTask taskType) {

--- a/src/test/java/uk/gov/hmcts/reform/fpl/dmn/CamundaTaskWaConfigurationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/fpl/dmn/CamundaTaskWaConfigurationTest.java
@@ -609,7 +609,7 @@ class CamundaTaskWaConfigurationTest extends DmnDecisionTableBaseUnitTest {
     void shouldHaveCorrectNumberOfRules() {
         // The purpose of this test is to prevent adding new rows without being tested
         DmnDecisionTableImpl logic = (DmnDecisionTableImpl) decision.getDecisionLogic();
-        assertThat(logic.getRules().size(), is(68));
+        assertThat(logic.getRules().size(), is(69));
     }
 
     private static List<Map<String, Object>> getBaseValues() {

--- a/src/test/java/uk/gov/hmcts/reform/fpl/dmn/CamundaTaskWaInitiationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/fpl/dmn/CamundaTaskWaInitiationTest.java
@@ -99,8 +99,8 @@ class CamundaTaskWaInitiationTest extends DmnDecisionTableBaseUnitTest {
                     "court", Map.of("code", "151")
                 ),
                 Map.of(
-                    "taskId", "reviewMessageLegalAdviser",
-                    "name", "Review Message (Legal Adviser)",
+                    "taskId", "reviewMessageOther",
+                    "name", "Review Message (Other Judiciary)",
                     "processCategories", CASE_PROGRESSION.getValue()
                 )
             ),

--- a/src/test/java/uk/gov/hmcts/reform/fpl/dmn/CamundaTaskWaPermissionsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/fpl/dmn/CamundaTaskWaPermissionsTest.java
@@ -74,7 +74,7 @@ class CamundaTaskWaPermissionsTest extends DmnDecisionTableBaseUnitTest {
     void shouldHaveCorrectNumberOfRules() {
         // The purpose of this test is to prevent adding new rows without being tested
         DmnDecisionTableImpl logic = (DmnDecisionTableImpl) decision.getDecisionLogic();
-        assertThat(logic.getRules().size(), is(25));
+        assertThat(logic.getRules().size(), is(27));
     }
 
     private static Map<String, Object> getRowResult(String name, String value, String roleCategory, String auth,


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DFPL-2664


### Change description ###
 - Change OTHER judicial messages to generic unassigned judicial messages
 - Enable permissions for all CTSC/Local Court Admins to assign judicial tasks


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
