### PR TITLE
DFPL-2727: Enable Review listing task for legal advisers

### DIFF
--- a/src/main/resources/wa-task-permissions-publiclaw-care_supervision_epo.dmn
+++ b/src/main/resources/wa-task-permissions-publiclaw-care_supervision_epo.dmn
@@ -551,6 +551,33 @@
           <text>false</text>
         </outputEntry>
       </rule>
+      <rule id="DecisionRule_17bwz38">
+        <description>DFPL-2727, allow Legal Advisers to complete listing action tasks</description>
+        <inputEntry id="UnaryTests_09u8u9o">
+          <text>"reviewListingAction"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_12xs5xa">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1fxklh1">
+          <text>"tribunal-caseworker"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_16175re">
+          <text>"Complete,Own,Assign,Claim,Unassign,Read"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1pfotjj">
+          <text>"LEGAL_OPERATIONS"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1jz4nsk">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1rze878">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_03776wp">
+          <text>false</text>
+        </outputEntry>
+      </rule>
       <rule id="DecisionRule_1oooaja">
         <description>DEPRECATED</description>
         <inputEntry id="UnaryTests_11vlyzo">

--- a/src/test/java/uk/gov/hmcts/reform/fpl/dmn/CamundaTaskWaPermissionsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/fpl/dmn/CamundaTaskWaPermissionsTest.java
@@ -74,7 +74,7 @@ class CamundaTaskWaPermissionsTest extends DmnDecisionTableBaseUnitTest {
     void shouldHaveCorrectNumberOfRules() {
         // The purpose of this test is to prevent adding new rows without being tested
         DmnDecisionTableImpl logic = (DmnDecisionTableImpl) decision.getDecisionLogic();
-        assertThat(logic.getRules().size(), is(27));
+        assertThat(logic.getRules().size(), is(28));
     }
 
     private static Map<String, Object> getRowResult(String name, String value, String roleCategory, String auth,


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DFPL-2727


### Change description ###
 - Allow Legal Advisers (tribunal-caseworkers) access to complete the Review listing action request task.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
