### PR TITLE
DFPL-3248: Change judge on generic approve orders task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ version = '0.0.1'
 
 java {
   toolchain {
-    languageVersion = JavaLanguageVersion.of(17)
+    languageVersion = JavaLanguageVersion.of(21)
   }
 }
 

--- a/src/main/resources/wa-task-permissions-publiclaw-care_supervision_epo.dmn
+++ b/src/main/resources/wa-task-permissions-publiclaw-care_supervision_epo.dmn
@@ -366,6 +366,60 @@
           <text>true</text>
         </outputEntry>
       </rule>
+      <rule id="DecisionRule_0rd62o0">
+        <description>Auto assigning</description>
+        <inputEntry id="UnaryTests_1ngggaj">
+          <text>"approveOrders"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_07jwie4">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0ea21nw">
+          <text>"allocated-judge"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0qpo9pb">
+          <text>"Complete,Own,Assign,Claim,Unassign,Read"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0z47fvg">
+          <text>"JUDICIAL"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0qjlauw">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1f5c65a">
+          <text>1</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0jibxs4">
+          <text>true</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1ql7bnz">
+        <description>Auto assigning</description>
+        <inputEntry id="UnaryTests_14bca3f">
+          <text>"approveOrders"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1waw2gm">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0e8gu5o">
+          <text>"allocated-legal-adviser"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0vdzf5p">
+          <text>"Complete,Own,Assign,Claim,Unassign,Read"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1vws5et">
+          <text>"LEGAL_OPERATIONS"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_04m3h68">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0yak6dk">
+          <text>2</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0odc7ae">
+          <text>true</text>
+        </outputEntry>
+      </rule>
       <rule id="DecisionRule_10ux7wt">
         <description></description>
         <inputEntry id="UnaryTests_1kf3gzz">
@@ -422,7 +476,7 @@
       <rule id="DecisionRule_0wx6m1d">
         <description>Auto assigning</description>
         <inputEntry id="UnaryTests_02y62xj">
-          <text>"approveOrders","approveOrdersHearingJudge"</text>
+          <text>"approveOrdersHearingJudge"</text>
         </inputEntry>
         <outputEntry id="LiteralExpression_1dordef">
           <text></text>
@@ -449,7 +503,7 @@
       <rule id="DecisionRule_002pzao">
         <description>Auto assigning</description>
         <inputEntry id="UnaryTests_1g0d3xf">
-          <text>"approveOrders","approveOrdersLegalAdviser"</text>
+          <text>"approveOrdersLegalAdviser"</text>
         </inputEntry>
         <outputEntry id="LiteralExpression_1hf0l9t">
           <text></text>

--- a/src/test/java/uk/gov/hmcts/reform/fpl/dmn/CamundaTaskWaPermissionsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/fpl/dmn/CamundaTaskWaPermissionsTest.java
@@ -74,7 +74,7 @@ class CamundaTaskWaPermissionsTest extends DmnDecisionTableBaseUnitTest {
     void shouldHaveCorrectNumberOfRules() {
         // The purpose of this test is to prevent adding new rows without being tested
         DmnDecisionTableImpl logic = (DmnDecisionTableImpl) decision.getDecisionLogic();
-        assertThat(logic.getRules().size(), is(32));
+        assertThat(logic.getRules().size(), is(34));
     }
 
     private static Map<String, Object> getRowResult(String name, String value, String roleCategory, String auth,


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DFPL-3248

Use allocated-judge and allocated-legal-adviser instead of hearing counterparts for generic approve orders tasks

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
